### PR TITLE
Make Ch33\LoadObj use InvariantCulture to improve internationalization

### DIFF
--- a/Ch33/LoadObj/App.xaml.cs
+++ b/Ch33/LoadObj/App.xaml.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Windows;
 
 namespace LoadObj
@@ -13,5 +15,12 @@ namespace LoadObj
     /// </summary>
     public partial class App : Application
     {
+        public App()
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+        }
+       
+        
     }
 }


### PR DESCRIPTION
Changed Ch33\LoadObj to use InvariantCulture, so that obj files can be parsed also on systems using "," as decimal separator.